### PR TITLE
build: add basic devcontainer setup

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -1,0 +1,1 @@
+setfacl

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends acl && \
+    rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "postStartCommand": [
+    "./.devcontainer/post-start.sh",
+    "${containerWorkspaceFolder}"
+  ],
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -ex
+
+# Run after the devcontainer has successfully started
+# https://containers.dev/implementors/json_reference/#lifecycle-scripts
+
+workspace_dir="${1:=}"
+
+if test -z "${workspace_dir}"; then
+    echo "Usage: ${0} WORKSPACE_DIR" >&2
+    exit 1
+fi
+
+# Remove ACLs on files in the workspace mount so that the default system umask
+# is respected
+# https://github.com/orgs/community/discussions/26026#discussioncomment-3250078
+sudo chown -R "$(whoami)" "${workspace_dir}"
+sudo setfacl -bnR "${workspace_dir}"


### PR DESCRIPTION
This change also adds a `post-start.sh` script to remove ACLs on files in the workspace mount so that the default system umask is respected.

This change is important because the primary purpose of this project is to copy files to the user's home directory, and the ownership and permissions should match the rest of the system.